### PR TITLE
Do not use the command attribute on a bash resource, use the 'code' a…

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,6 @@ bash "install_gdal_#{gdal_version}" do
     ./configure && make && make install && \
     ldconfig
   EOH
-  command ""
   not_if { ::File.exists? "/usr/local/bin/gdal-config" }
   action :run
 end


### PR DESCRIPTION
Chef::Exceptions::Script
------------------------
Do not use the command attribute on a bash resource, use the 'code' attribute instead.

Cookbook Trace:
---------------
  /home/ross/chef-solo/local-mode-cache/cache/cookbooks/gdal/recipes/default.rb:24:in `block in from_file'
  /home/ross/chef-solo/local-mode-cache/cache/cookbooks/gdal/recipes/default.rb:14:in `from_file'
  /home/ross/chef-solo/local-mode-cache/cache/cookbooks/Main/recipes/_geodb.rb:7:in `from_file'

Relevant File Content:
----------------------
/home/ross/chef-solo/local-mode-cache/cache/cookbooks/gdal/recipes/default.rb:

 17:    code <<-EOH
 18:      cd #{untar_dir} && \
 19:      tar xzvf /tmp/#{tarball_gz} && \
 20:      cd gdal-#{gdal_folder} && \
 21:      ./configure && make && make install && \
 22:      ldconfig
 23:    EOH
 24>>   command ""
 25:    creates "/usr/local/bin/gdal-config"
 26:    action :run
 27:  end
 28: